### PR TITLE
Add travis build

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: ruby
 rvm:
   - 2.6.3
+before_script:
+  - wget https://github.com/IMSGlobal/caliper-common-fixtures/archive/develop.zip
+  - unzip develop.zip -d spec/
+  - mv spec/caliper-common-fixtures-develop spec/fixtures

--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,5 @@ group :development, :test do
   gem 'simplecov-rcov', :require => false, :group => :test
   gem 'mocha', '~> 1.1.0'
   gem 'json_spec'
+  gem 'rake'
 end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IMS Global Learning Consortium, Inc.
 
+[![Build Status](https://travis-ci.org/IMSGlobal/caliper-ruby.svg?branch=develop)](https://travis-ci.org/IMSGlobal/caliper-ruby)
+
 # caliper-ruby
 
 The [Caliper Analytics&reg; Specification](https://www.imsglobal.org/caliper/v1p1/caliper-spec-v1p1) 
@@ -40,10 +42,11 @@ development machine.
 
 #### Note
 To run specs, you need to clone [caliper-common-fixtures](https://github.com/IMSGlobal/caliper-common-fixtures) 
-at the same level as *caliper-ruby*. Then create a symlink similar to
+at the same level as *caliper-ruby*. This library is currently setup to run against the `develop` branch of the
+ fixtures repo, so check that out. Then create a symlink similar to
 
 ```
-➜ caliper-ruby git:(master) ln -s ../../caliper-common-fixtures/src/test/resources/fixtures ./spec/fixtures
+➜ caliper-ruby git:(develop) ln -s ../../caliper-common-fixtures ./spec/fixtures
 
 ```
 

--- a/rakefile
+++ b/rakefile
@@ -1,0 +1,7 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+end
+task :default => :spec

--- a/spec/lib/request/http_requestor_batch_event_spec.rb
+++ b/spec/lib/request/http_requestor_batch_event_spec.rb
@@ -162,7 +162,7 @@ describe Caliper::Request::Envelope do
 
     # Load JSON from caliper-common-fixtures for comparison
     # NOTE - sym link to caliper-common-fixtures needs to exist under spec/fixtures
-    json_string = File.read('spec/fixtures/caliperEnvelopeEventBatch.json')
+    json_string = File.read(File.join(FIXTURE_DIR, 'caliperEnvelopeEventBatch.json'))
     expect(json_payload).to be_json_eql(json_string)
   end
 end

--- a/spec/lib/request/http_requestor_single_event_spec.rb
+++ b/spec/lib/request/http_requestor_single_event_spec.rb
@@ -111,7 +111,7 @@ describe Caliper::Request::Envelope do
 
     # Load JSON from caliper-common-fixtures for comparison
     # NOTE - sym link to caliper-common-fixtures needs to exist under spec/fixtures
-    json_string = File.read('spec/fixtures/caliperEnvelopeEventSingle.json')
+    json_string = File.read(File.join(FIXTURE_DIR, 'caliperEnvelopeEventSingle.json'))
     expect(json_payload).to be_json_eql(json_string)
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -19,7 +19,7 @@ shared_examples 'validation against common fixture' do |fixture_filename, option
   options ||= {}
 
   # Load fixture JSON from caliper-common-fixtures, which should be symlinked under spec/fixtures.
-  let(:fixture_json) { File.read("spec/fixtures/#{fixture_filename}") }
+  let(:fixture_json) { File.read(File.join(FIXTURE_DIR, fixture_filename) ) }
 
   it 'should be equal in serialized form' do
     json = subject.to_json(options)
@@ -36,7 +36,7 @@ shared_examples 'payload validation against common fixture' do |fixture_filename
   options ||= {}
 
   # Load fixture JSON from caliper-common-fixtures, which should be symlinked under spec/fixtures.
-  let(:fixture_json) { File.read("spec/fixtures/#{fixture_filename}") }
+  let(:fixture_json) { File.read( File.join(FIXTURE_DIR, fixture_filename) ) }
 
   let(:caliper_options) { Caliper::Options.new }
   let(:sensor) { Caliper::Sensor.new(sensor_id, caliper_options) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,14 @@ require 'simplecov'
 require 'simplecov-rcov'
 
 require_relative '../lib/caliper'
+
+unless defined? FIXTURE_DIR
+  FIXTURE_DIR_1_0 = "spec/fixtures/v1p0/"
+  FIXTURE_DIR_1_1 = "spec/fixtures/v1p1/"
+  FIXTURE_DIR_1_2 = "spec/fixtures/v1p2/"
+  FIXTURE_DIR = FIXTURE_DIR_1_1
+end
+
 require 'shared_examples'
 
 # Do not exclude 'id' keys from comparison.


### PR DESCRIPTION
This adds a travis build file and also updates the specs to run against the newer fixture directory structure so you'll have to update your local development environment accordingly.

The new setup for the fixtures is to check out the *development* branch instead of the master branch of caliper-common-fixtures and symlink that directory into `spec/fixtures`. 

See updated note in the readme: https://github.com/IMSGlobal/caliper-ruby/tree/add_travis#note